### PR TITLE
Hotfix: Test mode 

### DIFF
--- a/classes/WPC2O_Notice.php
+++ b/classes/WPC2O_Notice.php
@@ -35,7 +35,7 @@ class WPC2O_Notice
     {
 ?>
         <div class="notice notice-<?php echo esc_html($this->servierty); ?> <?php esc_html($this->dissmissible) ?: 'is-dismissible'; ?>">
-            <p><?php esc_html_e($this->message, 'wpc2o'); ?></p>
+            <p><?php echo $this->message; ?></p>
         </div>
 <?php
     }

--- a/includes/wpc2o-options-api.php
+++ b/includes/wpc2o-options-api.php
@@ -9,6 +9,7 @@ function wpc2o_get_api_view(): string
     $content           = '<h1>API Credentials</h1>';
     $content          .= '<div style="padding:6px 0;">';
     $content          .= '<ol style="margin-left: 16px;">';
+    $content          .= '<li>Test mode: <strong>' . get_option(constant('WPC2O_API_TEST_MODE')) . '</strong></li>';
     $content          .= '<li>Key: <strong>' . get_option(constant('WPC2O_API_KEY')) . '</strong></li>';
     $content          .= '<li>Order endpoint: <strong>' . get_option(constant('WPC2O_API_ENDPOINT')) . '</strong></li>';
     $content          .= '<li>Stock endpoint: <strong>' . get_option(constant('WPC2O_API_STOCK_ENDPOINT')) . '</strong></li>';

--- a/includes/wpc2o-orders.php
+++ b/includes/wpc2o-orders.php
@@ -31,6 +31,13 @@ function wpc2o_process_completed_order(int $order_id): void
             $api_key           = get_option(constant('WPC2O_API_KEY'));
             $delivery_method   = carbon_get_theme_option(constant('WPC2O_DELIVERY_OPTION'));
 
+            if ($test_mode === 'yes') {
+                $test_mode = true;
+            }
+            if ($test_mode === 'no') {
+                $test_mode = false;
+            }
+
             $order_request = new WPC2O_OrderRequest();
             $order->add_order_note('Order request has been sent to Clothes2Order, waiting for their response...');
             $response_message = $order_request->send($api_post_endpoint, $test_mode, $api_key, $delivery_method, $order, $products);

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,6 +26,7 @@
         <exclude name="WordPress.Files.FileName.InvalidClassFileName" />
         <exclude name="WordPress.WP.I18n.NonSingularStringLiteralText" />
         <exclude name="WordPress.WP.AlternativeFunctions.curl_curl_init" />
+        <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
         <exclude name="WordPress.WP.AlternativeFunctions.curl_curl_exec" />
         <exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
         <exclude name="WordPress.WP.AlternativeFunctions.curl_curl_close" />


### PR DESCRIPTION
- Added test mode list item to plugin options screen.
- Fixed html parsing of notice
- Added ignore to not escape html on for phpcs

# Pull request

### Please explain the purpose of this request.

The purpose of this pull request was to fix testmode so when disabled, it will not send the testmode header to C2O

### Contributions

Have you read our [CONTRIBUTING](https://github.com/AshleyRedman/WPClothes2Order/blob/main/.github/CONTRIBUTING.md#submit-changes-by-creating-a-pr) file & believe you have followed the steps appropriately?

...
